### PR TITLE
Bump OpenClaw to 2026.2.2-3

### DIFF
--- a/openclaw_assistant/Dockerfile
+++ b/openclaw_assistant/Dockerfile
@@ -83,7 +83,7 @@ USER root
 
 # Install OpenClaw globally
 RUN npm config set fund false && npm config set audit false \
- && npm install -g openclaw@2026.2.2-3
+ && npm install -g openclaw@2026.2.2-3-3
 
 COPY run.sh /run.sh
 COPY oc_config_helper.py /oc_config_helper.py


### PR DESCRIPTION
Automated update:
- openclaw_assistant/Dockerfile: openclaw@2026.2.2 → openclaw@2026.2.2-3
- openclaw_assistant/config.yaml: add-on version 0.5.32 → 0.5.33

By OpenClaw Home Assistant Bot.