### PR TITLE
Bump OpenClaw to 2026.2.3-1

### DIFF
--- a/openclaw_assistant/Dockerfile
+++ b/openclaw_assistant/Dockerfile
@@ -83,7 +83,7 @@ USER root
 
 # Install OpenClaw globally
 RUN npm config set fund false && npm config set audit false \
- && npm install -g openclaw@2026.2.2-3
+ && npm install -g openclaw@2026.2.3-1-3
 
 COPY run.sh /run.sh
 COPY oc_config_helper.py /oc_config_helper.py

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.34"
+version: "0.5.35"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant


### PR DESCRIPTION
Automated update:
- openclaw_assistant/Dockerfile: openclaw@2026.2.2 → openclaw@2026.2.3-1
- openclaw_assistant/config.yaml: add-on version 0.5.34 → 0.5.35

By OpenClaw Home Assistant Bot.