### PR TITLE
Integrating OpenClaw with Home Assistant Assist pipeline

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -169,6 +169,11 @@ Control how the OpenClaw gateway operates and binds to the network:
   - Port number for the gateway to listen on
   - Only applies when `gateway_mode` is **local**
 
+- **`enable_openai_api`** (bool, default **false**)
+  - Enable the OpenAI-compatible Chat Completions endpoint (`/v1/chat/completions`)
+  - Required for integrating with HA Assist pipeline via [Extended OpenAI Conversation](https://github.com/jekalmin/extended_openai_conversation)
+  - See section 6 for full setup instructions
+
 - **`allow_insecure_auth`** (bool, default **false**)
   - Allow HTTP authentication for gateway access on LAN
   - **WARNING**: Only enable if using HTTP (not HTTPS) for `gateway_public_url`
@@ -206,6 +211,81 @@ How to provide the key:
 ### Session cleanup
 - `clean_session_locks_on_start` (bool, default **true**) — Remove stale lock files on startup
 - `clean_session_locks_on_exit` (bool, default **true**) — Remove stale lock files on shutdown
+
+---
+
+## 6) Integrate with Home Assistant Assist Pipeline
+
+OpenClaw's Gateway exposes an **OpenAI-compatible Chat Completions endpoint**. This means you can use OpenClaw as a **conversation agent** in Home Assistant's Assist pipeline — enabling voice control, automations, and smart home commands powered by OpenClaw.
+
+### How it works
+
+1. OpenClaw Gateway serves `POST /v1/chat/completions` (same port as the gateway)
+2. [Extended OpenAI Conversation](https://github.com/jekalmin/extended_openai_conversation) (HACS integration) connects HA's Assist pipeline to any OpenAI-compatible endpoint
+3. Both run on the same machine, so communication is via `127.0.0.1`
+
+### Step 1 — Enable the OpenAI API endpoint
+
+**Via add-on configuration (recommended)**:
+1. Go to Home Assistant → **Settings → Add-ons → OpenClaw Assistant → Configuration**
+2. Set `enable_openai_api`: **true**
+3. Restart the add-on
+
+**Via terminal (manual)**:
+```sh
+openclaw config set gateway.http.endpoints.chatCompletions.enabled true
+```
+
+### Step 2 — Install Extended OpenAI Conversation
+
+1. Install [HACS](https://hacs.xyz/) if you haven't already
+2. In HACS, add **Extended OpenAI Conversation** as a custom repository:
+   - Repository: `https://github.com/jekalmin/extended_openai_conversation`
+   - Category: **Integration**
+3. Install it and restart Home Assistant
+
+### Step 3 — Get your Gateway token
+
+In the add-on terminal, run:
+
+```sh
+openclaw config get gateway.auth.token
+```
+
+Copy the token — you'll need it as the API key.
+
+### Step 4 — Configure Extended OpenAI Conversation
+
+1. Go to **Settings → Devices & Services → Add Integration**
+2. Search for **Extended OpenAI Conversation**
+3. Configure:
+   - **API Key**: Paste your gateway token
+   - **Base URL**: `http://127.0.0.1:18789/v1` or a LAN url if you use `gateway_bind_mode: lan`
+   - **Api Version**: leave empty
+   - **Organization**: leave empty
+   - **Skip Authentication**: **true**
+
+### Step 5 — Set as Conversation Agent
+
+1. Go to **Settings → Voice Assistants**
+2. Edit your assistant (default: "Home Assistant")
+3. Under **Conversation agent**, select **Extended OpenAI Conversation**
+
+### Step 6 — Expose entities
+
+Expose the entities you want OpenClaw to control:
+- Go to `http://{your-ha}/config/voice-assistants/expose`
+- Toggle on the entities OpenClaw should be able to see and control
+
+### Done!
+
+You can now use Assist (voice or text) and OpenClaw will handle the conversation. It can:
+- Control your smart home devices
+- Answer questions using its skills
+- Create automations
+- Query entity history
+
+**Tip**: If using LAN access (`gateway_bind_mode: lan`), other HA instances on your network can also connect to this endpoint.
 
 ---
 

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.36"
+version: "0.5.37"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant
@@ -65,6 +65,11 @@ options:
   # Gateway port to listen on
   gateway_port: 18789
 
+  # Enable OpenAI-compatible Chat Completions API endpoint
+  # When enabled, OpenClaw can be used as a conversation agent in HA Assist pipeline
+  # via Extended OpenAI Conversation (HACS) or any OpenAI-compatible client
+  enable_openai_api: false
+
   # Allow insecure HTTP authentication (required for HTTP gateway access on LAN)
   # WARNING: Only enable if you're using HTTP (not HTTPS) for gateway_public_url
   # Default is false for security.
@@ -87,5 +92,6 @@ schema:
   gateway_mode: list(local|remote)?
   gateway_bind_mode: list(loopback|lan)?
   gateway_port: int(1,65535)?
+  enable_openai_api: bool?
   allow_insecure_auth: bool?
 

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -48,6 +48,7 @@ CLEAN_LOCKS_ON_EXIT=$(jq -r '.clean_session_locks_on_exit // true' "$OPTIONS_FIL
 GATEWAY_MODE=$(jq -r '.gateway_mode // "local"' "$OPTIONS_FILE")
 GATEWAY_BIND_MODE=$(jq -r '.gateway_bind_mode // "loopback"' "$OPTIONS_FILE")
 GATEWAY_PORT=$(jq -r '.gateway_port // 18789' "$OPTIONS_FILE")
+ENABLE_OPENAI_API=$(jq -r '.enable_openai_api // false' "$OPTIONS_FILE")
 ALLOW_INSECURE_AUTH=$(jq -r '.allow_insecure_auth // false' "$OPTIONS_FILE")
 
 export TZ="$TZNAME"
@@ -233,7 +234,7 @@ fi
 
 if [ -f "$OPENCLAW_CONFIG_PATH" ]; then
   if [ -f "$HELPER_PATH" ]; then
-    if ! python3 "$HELPER_PATH" apply-gateway-settings "$GATEWAY_MODE" "$GATEWAY_BIND_MODE" "$GATEWAY_PORT" "$ALLOW_INSECURE_AUTH"; then
+    if ! python3 "$HELPER_PATH" apply-gateway-settings "$GATEWAY_MODE" "$GATEWAY_BIND_MODE" "$GATEWAY_PORT" "$ENABLE_OPENAI_API" "$ALLOW_INSECURE_AUTH"; then
       rc=$?
       echo "ERROR: Failed to apply gateway settings via oc_config_helper.py (exit code ${rc})."
       echo "ERROR: Gateway configuration may be incorrect; aborting startup."

--- a/openclaw_assistant/translations/bg.yaml
+++ b/openclaw_assistant/translations/bg.yaml
@@ -51,6 +51,10 @@ configuration:
     name: Порт на Gateway
     description: Номер на порт, на който OpenClaw gateway да слуша (по подразбиране - 18789)
   
+  enable_openai_api:
+    name: Активиране на OpenAI API
+    description: Активиране на OpenAI-съвместим Chat Completions ендпойнт. Позволява използването на OpenClaw като разговорен агент в HA Assist pipeline чрез Extended OpenAI Conversation (HACS) или всеки OpenAI-съвместим клиент.
+  
   allow_insecure_auth:
     name: Разрешаване на HTTP автентикация
     description: Разрешаване на HTTP автентикация за достъп до gateway в локалната мрежа. ВНИМАНИЕ - Активирайте само ако използвате HTTP (не HTTPS) за gateway_public_url. Необходимо за достъп от браузър през HTTP.

--- a/openclaw_assistant/translations/de.yaml
+++ b/openclaw_assistant/translations/de.yaml
@@ -51,6 +51,10 @@ configuration:
     name: Gateway-Port
     description: Portnummer, auf der das OpenClaw-Gateway lauscht (Standard - 18789)
   
+  enable_openai_api:
+    name: OpenAI API aktivieren
+    description: OpenAI-kompatiblen Chat Completions Endpunkt aktivieren. Ermöglicht die Verwendung von OpenClaw als Gesprächsagent in der HA Assist Pipeline über Extended OpenAI Conversation (HACS) oder jeden OpenAI-kompatiblen Client.
+  
   allow_insecure_auth:
     name: Unsichere HTTP-Authentifizierung erlauben
     description: HTTP-Authentifizierung für Gateway-Zugriff im LAN erlauben. WARNUNG - Nur aktivieren, wenn HTTP (nicht HTTPS) für gateway_public_url verwendet wird. Erforderlich für Browser-Zugriff über HTTP.

--- a/openclaw_assistant/translations/en.yaml
+++ b/openclaw_assistant/translations/en.yaml
@@ -51,6 +51,10 @@ configuration:
     name: Gateway Port
     description: Port number for the OpenClaw gateway to listen on (default - 18789)
   
+  enable_openai_api:
+    name: Enable OpenAI API
+    description: Enable OpenAI-compatible Chat Completions endpoint. Allows using OpenClaw as a conversation agent in HA Assist pipeline via Extended OpenAI Conversation (HACS) or any OpenAI-compatible client.
+  
   allow_insecure_auth:
     name: Allow Insecure HTTP Auth
     description: Allow HTTP authentication for gateway access on LAN. WARNING - Only enable if using HTTP (not HTTPS) for gateway_public_url. Required for browser access over HTTP.

--- a/openclaw_assistant/translations/es.yaml
+++ b/openclaw_assistant/translations/es.yaml
@@ -51,6 +51,10 @@ configuration:
     name: Puerto del Gateway
     description: Número de puerto en el que el gateway de OpenClaw escuchará (predeterminado - 18789)
   
+  enable_openai_api:
+    name: Activar API OpenAI
+    description: Activar endpoint de Chat Completions compatible con OpenAI. Permite usar OpenClaw como agente de conversación en HA Assist pipeline mediante Extended OpenAI Conversation (HACS) o cualquier cliente compatible con OpenAI.
+  
   allow_insecure_auth:
     name: Permitir autenticación HTTP insegura
     description: Permitir autenticación HTTP para acceso al gateway en LAN. ADVERTENCIA - Solo habilitar si usa HTTP (no HTTPS) para gateway_public_url. Requerido para acceso desde navegador por HTTP.

--- a/openclaw_assistant/translations/pl.yaml
+++ b/openclaw_assistant/translations/pl.yaml
@@ -47,6 +47,10 @@ configuration:
     name: Port Gateway
     description: Numer portu na którym gateway OpenClaw będzie nasłuchiwał (domyślnie - 18789)
   
+  enable_openai_api:
+    name: Włącz API OpenAI
+    description: Włącz endpoint Chat Completions kompatybilny z OpenAI. Pozwala używać OpenClaw jako agenta konwersacji w HA Assist pipeline przez Extended OpenAI Conversation (HACS) lub dowolnego klienta kompatybilnego z OpenAI.
+  
   allow_insecure_auth:
     name: Zezwól na niezabezpieczone uwierzytelnianie HTTP
     description: Zezwól na uwierzytelnianie HTTP dla dostępu do gateway w sieci LAN. UWAGA - Włącz tylko jeśli używasz HTTP (nie HTTPS) dla gateway_public_url. Wymagane dla dostępu przez przeglądarkę przez HTTP.


### PR DESCRIPTION
- Introduced `enable_openai_api` option in config.yaml to enable OpenAI-compatible Chat Completions endpoint.
- Updated `apply_gateway_settings` function to handle OpenAI API settings.
- Enhanced documentation in DOCS.md for integrating OpenClaw with Home Assistant Assist pipeline.
- Added translations for `enable_openai_api` in English, Bulgarian, German, Spanish, and Polish.
- Bumped version to 0.5.37 in config.yaml.