### PR TITLE
Bump OpenClaw to 2026.2.9

### DIFF
--- a/openclaw_assistant/Dockerfile
+++ b/openclaw_assistant/Dockerfile
@@ -97,7 +97,7 @@ USER root
 
 # Install OpenClaw globally
 RUN npm config set fund false && npm config set audit false \
- && npm install -g openclaw@2026.2.6-3
+ && npm install -g openclaw@2026.2.9-3
 
 COPY run.sh /run.sh
 COPY oc_config_helper.py /oc_config_helper.py

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.37"
+version: "0.5.38"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant


### PR DESCRIPTION
Automated update:
- openclaw_assistant/Dockerfile: openclaw@2026.2.6 → openclaw@2026.2.9
- openclaw_assistant/config.yaml: add-on version 0.5.37 → 0.5.38

By OpenClaw Home Assistant Bot.