### PR TITLE
Make nginx ingress port configurable

### DIFF
--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -25,6 +25,9 @@ map:
 options:
   timezone: "Europe/Sofia"
 
+  # Ingress port (nginx listens on this port for Home Assistant Ingress)
+  ingress_port: 8099
+
   # Enable web terminal inside Home Assistant (Ingress) via ttyd
   enable_terminal: true
 
@@ -78,6 +81,7 @@ options:
 
 schema:
   timezone: str
+  ingress_port: int(1024,65535)?
   enable_terminal: bool?
   terminal_port: int(1024,65535)?
   gateway_public_url: str?

--- a/openclaw_assistant/nginx.conf.tpl
+++ b/openclaw_assistant/nginx.conf.tpl
@@ -19,7 +19,7 @@ http {
   # Ingress note: keep redirects relative so we stay under HA Ingress.
 
   server {
-    listen 8099;
+    listen __INGRESS_PORT__;
 
     # Web terminal (ttyd)
     # ttyd base-path is configured as /terminal (no trailing slash).


### PR DESCRIPTION
Sorry I'm no expert in this, and I lack the time so I used Claude to create this PR:

- Add ingress_port option to add-on configuration (default: 8099)
- Update nginx.conf.tpl to use __INGRESS_PORT__ placeholder
- Add port validation in run.sh (range 1024-65535)
- Update template processing to inject configured port value
- Add ingress_port to configuration schema with validation