### PR TITLE
Add CHANGELOG.md for Home Assistant update dialog

### DIFF
--- a/openclaw_assistant/CHANGELOG.md
+++ b/openclaw_assistant/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to the OpenClaw Assistant Home Assistant Add-on will be documented in this file.
+
+## [0.5.41] - 2026-02-11
+
+### Changed
+- Update Dockerfile, config.yaml, and run.sh for enhancements
+- Update icon and logo images for improved quality
+
+## [0.5.40] - 2026-02-11
+
+### Added
+- Additional tools in Dockerfile
+
+### Changed
+- Improved nginx process management in run.sh
+
+## [0.5.39] - 2026-02-10
+
+### Fixed
+- Fix OpenClaw installation command in Dockerfile
+
+## [0.5.38] - 2026-02-10
+
+### Changed
+- Bump OpenClaw to 2026.2.9
+
+## [0.5.37] - 2026-02-09
+
+### Added
+- OpenAI API integration for Home Assistant Assist pipeline
+- Updated translations
+
+## [0.5.36] - 2026-02-08
+
+### Changed
+- Documentation updates
+
+## [0.5.35] - 2026-02-08
+
+### Changed
+- Update Dockerfile for Homebrew installation improvements
+
+## [0.5.34] - 2026-02-08
+
+### Added
+- Install pnpm globally
+
+### Changed
+- Upgrade OpenClaw version to 2026.2.6-3
+
+## [0.5.33] - 2026-02-06
+
+### Changed
+- Enhanced README with images and updated setup instructions
+
+---
+
+For the full commit history, see [GitHub commits](https://github.com/techartdev/OpenClawHomeAssistant/commits/main).


### PR DESCRIPTION
## Summary

This PR adds a CHANGELOG.md file to the openclaw_assistant/ folder so Home Assistant displays version changes when updating the add-on.

## Problem

Currently, when updating the add-on, Home Assistant shows:
> No changelog found for add-on 17e0cc66_openclaw_assistant!

## Solution

Added CHANGELOG.md following Home Assistant add-on documentation format with recent version history.

## References

- [Home Assistant Add-on Documentation](https://developers.home-assistant.io/docs/apps/configuration/)

---

🧦 PR created with love by Zgredek