### PR TITLE
feat: add tailnet and auto bind mode support

### DIFF
--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -57,8 +57,10 @@ options:
   gateway_mode: local
 
   # Gateway network bind mode:
-  # - loopback: bind to 127.0.0.1 only (local access only, more secure)
+  # - loopback: bind to 127.0.0.1 only (local access only, most secure)
   # - lan: bind to all interfaces (accessible from local network)
+  # - tailnet: bind to Tailscale IP only (accessible only via Tailscale — recommended for remote access)
+  # - auto: prefer loopback; use tailnet if Tailscale is available
   # Default is loopback for security.
   gateway_bind_mode: loopback
 
@@ -95,7 +97,7 @@ schema:
   clean_session_locks_on_start: bool?
   clean_session_locks_on_exit: bool?
   gateway_mode: list(local|remote)?
-  gateway_bind_mode: list(loopback|lan)?
+  gateway_bind_mode: list(loopback|lan|tailnet|auto)?
   gateway_port: int(1,65535)?
   enable_openai_api: bool?
   allow_insecure_auth: bool?

--- a/openclaw_assistant/oc_config_helper.py
+++ b/openclaw_assistant/oc_config_helper.py
@@ -63,7 +63,7 @@ def apply_gateway_settings(mode: str, bind_mode: str, port: int, enable_openai_a
     
     Args:
         mode: "local" or "remote"
-        bind_mode: "loopback" or "lan"
+        bind_mode: "loopback", "lan", "tailnet", or "auto"
         port: Port number to listen on (must be 1-65535)
         enable_openai_api: Enable OpenAI-compatible Chat Completions endpoint
         allow_insecure_auth: Allow insecure HTTP authentication
@@ -74,8 +74,8 @@ def apply_gateway_settings(mode: str, bind_mode: str, port: int, enable_openai_a
         return False
     
     # Validate bind mode
-    if bind_mode not in ["loopback", "lan"]:
-        print(f"ERROR: Invalid bind_mode '{bind_mode}'. Must be 'loopback' or 'lan'")
+    if bind_mode not in ["loopback", "lan", "tailnet", "auto"]:
+        print(f"ERROR: Invalid bind_mode '{bind_mode}'. Must be 'loopback', 'lan', 'tailnet', or 'auto'")
         return False
     
     # Validate port range
@@ -157,7 +157,7 @@ def main():
     
     if cmd == "apply-gateway-settings":
         if len(sys.argv) != 7:
-            print("Usage: oc_config_helper.py apply-gateway-settings <local|remote> <loopback|lan> <port> <enable_openai_api:true|false> <allow_insecure:true|false>")
+            print("Usage: oc_config_helper.py apply-gateway-settings <local|remote> <loopback|lan|tailnet|auto> <port> <enable_openai_api:true|false> <allow_insecure:true|false>")
             sys.exit(1)
         mode = sys.argv[2]
         bind_mode = sys.argv[3]


### PR DESCRIPTION
## Summary

OpenClaw natively supports `tailnet` and `auto` bind modes, but the add-on rejected them with a validation error in `oc_config_helper.py` and the `config.yaml` schema did not list them as valid options.

## Changes

- **`oc_config_helper.py`**: expand `bind_mode` validation to accept `tailnet` and `auto` in addition to `loopback` and `lan`
- **`config.yaml`**: add `tailnet` and `auto` to the `gateway_bind_mode` schema and document them in the options comments

## Why this matters

Users running Tailscale as a separate HA add-on (in non-userspace/kernel mode) can now set `gateway_bind_mode: tailnet` to restrict gateway access exclusively to their Tailscale network — no iptables rules or NPM reverse proxy needed for network isolation. Combined with token auth, this is the most secure setup for remote access.

Closes #59

---

Note: This PR was generated by openclaw w/ Claude Sonnet 4.6.