### PR TITLE
Bump OpenClaw to 2026.2.22-2

### DIFF
--- a/openclaw_assistant/Dockerfile
+++ b/openclaw_assistant/Dockerfile
@@ -102,7 +102,7 @@ USER root
 
 # Install OpenClaw globally (official npm release)
 RUN npm config set fund false && npm config set audit false \
- && npm install -g openclaw@2026.2.21-2
+ && npm install -g openclaw@2026.2.22-2-2
 
 # Shell aliases and color options for interactive use
 RUN tee -a /etc/bash.bashrc <<'EOF'

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.49"
+version: "0.5.50"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant


### PR DESCRIPTION
Automated update:
- openclaw_assistant/Dockerfile: openclaw@2026.2.21 → openclaw@2026.2.22-2
- openclaw_assistant/config.yaml: add-on version 0.5.49 → 0.5.50

By OpenClaw Home Assistant Bot.