### PR TITLE
Bump OpenClaw to 2026.3.7

### DIFF
--- a/openclaw_assistant/Dockerfile
+++ b/openclaw_assistant/Dockerfile
@@ -114,7 +114,7 @@ USER root
 
 # Install OpenClaw globally
 RUN npm config set fund false && npm config set audit false \
- && npm install -g openclaw@2026.3.2
+ && npm install -g openclaw@2026.3.7
 
 # Shell aliases and color options for interactive use
 RUN tee -a /etc/bash.bashrc <<'EOF'

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.57"
+version: "0.5.58"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant


### PR DESCRIPTION
Automated update:
- openclaw_assistant/Dockerfile: openclaw@2026.3.2 → openclaw@2026.3.7
- openclaw_assistant/config.yaml: add-on version 0.5.57 → 0.5.58

By OpenClaw Home Assistant Bot.