### PR TITLE
chore: bump OpenClaw to 2026.4.2

### DIFF
--- a/openclaw_assistant/CHANGELOG.md
+++ b/openclaw_assistant/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the OpenClaw Assistant Home Assistant Add-on will be documented in this file.
 
+## [0.5.65] - 2026-04-04
+
+### Changed
+- Bump OpenClaw to 2026.4.2.
+
 ## [0.5.63] - 2026-03-14
 
 ### Changed

--- a/openclaw_assistant/Dockerfile
+++ b/openclaw_assistant/Dockerfile
@@ -114,7 +114,7 @@ USER root
 
 # Install OpenClaw globally
 RUN npm config set fund false && npm config set audit false \
-    && npm install -g openclaw@2026.3.13
+    && npm install -g openclaw@2026.4.2
 
 # Shell aliases and color options for interactive use
 RUN tee -a /etc/bash.bashrc <<'EOF'

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.63"
+version: "0.5.65"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant


### PR DESCRIPTION
$## Summary\n- pull latest upstream main\n- bump bundled OpenClaw from 2026.3.13 to 2026.4.2\n- bump add-on version to 0.5.65\n- add changelog entry for 0.5.65\n\n## Notes\n- based on the latest upstream `main` at the time of update\n- no functional add-on code changes beyond the version bump