### PR TITLE
feat: auto-update on startup and doctor fix for post-upgrade config errors

### DIFF
--- a/openclaw_assistant/CHANGELOG.md
+++ b/openclaw_assistant/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the OpenClaw Assistant Home Assistant Add-on will be documented in this file.
 
+## [0.5.67.10] - 2026-04-24
+
+### Fixed
+- **Gateway startup failure: `typebox/compile` subpath not exported**: the previous workaround substituted `@sinclair/typebox` for the broken bundled `typebox`, but the two packages have different subpath layouts — `@sinclair/typebox` exposes `./compiler`, while `typebox` (1.x) exposes `./compile`, which `@mariozechner/pi-coding-agent` imports. `run.sh` now reinstalls the real `typebox` package fresh from npm (preferring openclaw's pinned version) and symlinks it in place. Detection now probes both the top-level `Type` export and the `./compile` subpath via an actual ESM `import('typebox/compile')`.
+
 ## [0.5.67.9] - 2026-04-24
 
 ### Fixed

--- a/openclaw_assistant/CHANGELOG.md
+++ b/openclaw_assistant/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the OpenClaw Assistant Home Assistant Add-on will be documented in this file.
 
+## [0.5.67.9] - 2026-04-24
+
+### Fixed
+- **Gateway startup failure on OpenClaw 2026.4.22+ due to broken bundled `@modelcontextprotocol/sdk`**: Node rejects the bundled package with `ERR_INVALID_PACKAGE_CONFIG` when resolving `@modelcontextprotocol/sdk/client/index.js`, crashing the gateway. `run.sh` now detects the failure by attempting the exact ESM import inside openclaw's install, then installs a fresh `@modelcontextprotocol/sdk` globally (preferring the version pinned in openclaw's `package.json`) and symlinks it over the broken bundled copy. Mirrors the existing `typebox` workaround.
+
 ## [0.5.66] - 2026-04-04
 
 ### Fixed

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.67.8"
+version: "0.5.67.9"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.67.9"
+version: "0.5.67.10"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -138,6 +138,10 @@ options:
   # MCP server in OpenClaw so the AI can control Home Assistant entities/services.
   auto_configure_mcp: false
 
+  # Automatically check for and install OpenClaw updates on add-on startup.
+  # Default: false (manual updates via add-on rebuild are recommended).
+  auto_update: false
+
 
 schema:
   timezone: str
@@ -169,3 +173,4 @@ schema:
       value: str
   nginx_log_level: list(full|minimal)?
   auto_configure_mcp: bool?
+  auto_update: bool?

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.66"
+version: "0.5.67.8"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -534,7 +534,19 @@ TYPEBOX_DIR="$NPM_GLOBAL_ROOT/openclaw/node_modules/typebox"
 SINCLAIR_DIR="$NPM_GLOBAL_ROOT/@sinclair/typebox"
 
 if [ -d "$TYPEBOX_DIR" ]; then
-  TYPEBOX_MAIN="$TYPEBOX_DIR/dist/esm/index.mjs"
+  # Discover the actual module entry point from package.json (module > main)
+  TYPEBOX_MAIN=""
+  TYPEBOX_PKG="$TYPEBOX_DIR/package.json"
+  if [ -f "$TYPEBOX_PKG" ]; then
+    TYPEBOX_MAIN=$(jq -r 'if .module then (.module | sub("^\\./"; "")) elif .main then (.main | sub("^\\./"; "")) else empty end' "$TYPEBOX_PKG")
+    if [ -n "$TYPEBOX_MAIN" ]; then
+      TYPEBOX_MAIN="$TYPEBOX_DIR/$TYPEBOX_MAIN"
+    fi
+  fi
+  # Fallback for legacy layouts
+  if [ -z "$TYPEBOX_MAIN" ] || [ ! -f "$TYPEBOX_MAIN" ]; then
+    TYPEBOX_MAIN="$TYPEBOX_DIR/dist/esm/index.mjs"
+  fi
   if [ -f "$TYPEBOX_MAIN" ] && ! grep -q 'export.*Type' "$TYPEBOX_MAIN" 2>/dev/null; then
     echo "INFO: Bundled typebox is missing Type export. Installing @sinclair/typebox..."
     npm install -g @sinclair/typebox@latest 2>&1 || true

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -516,6 +516,8 @@ if [ "$AUTO_UPDATE" = "true" ]; then
   LATEST_VER=$(npm view openclaw version 2>/dev/null || echo "")
   if [ -n "$LATEST_VER" ] && [ "$INSTALLED_VER" != "$LATEST_VER" ]; then
     echo "INFO: Updating OpenClaw $INSTALLED_VER → $LATEST_VER"
+    # Clean up leftover npm temp directories that cause ENOTEMPTY on rename
+    find "$(npm root -g)" -maxdepth 1 -name '.openclaw-*' -type d -exec rm -rf {} + 2>/dev/null || true
     npm install -g openclaw@latest 2>&1 || echo "WARN: Update failed, continuing with installed version"
   else
     echo "INFO: OpenClaw ${INSTALLED_VER:-unknown} is up to date"

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -531,24 +531,34 @@ fi
 # If the 'typebox' module is missing the 'Type' export, symlink it to @sinclair/typebox.
 # NOTE: npm global installs hoist deps to the global root, so check there first.
 NPM_GLOBAL_ROOT="$(npm root -g)"
+echo "DEBUG: npm root -g = $NPM_GLOBAL_ROOT"
 TYPEBOX_DIR="$NPM_GLOBAL_ROOT/typebox"
 SINCLAIR_DIR="$NPM_GLOBAL_ROOT/@sinclair/typebox"
+echo "DEBUG: typebox dir (hoisted) = $TYPEBOX_DIR (exists=$([ -d "$TYPEBOX_DIR" ] && echo yes || echo no))"
+echo "DEBUG: @sinclair/typebox dir (hoisted) = $SINCLAIR_DIR (exists=$([ -d "$SINCLAIR_DIR" ] && echo yes || echo no))"
 
 # Fallback: some npm versions keep deps under the package's own node_modules
 if [ ! -d "$TYPEBOX_DIR" ]; then
   TYPEBOX_DIR="$NPM_GLOBAL_ROOT/openclaw/node_modules/typebox"
+  echo "DEBUG: falling back to nested typebox dir = $TYPEBOX_DIR (exists=$([ -d "$TYPEBOX_DIR" ] && echo yes || echo no))"
 fi
 if [ ! -d "$SINCLAIR_DIR" ]; then
   SINCLAIR_DIR="$NPM_GLOBAL_ROOT/openclaw/node_modules/@sinclair/typebox"
+  echo "DEBUG: falling back to nested @sinclair/typebox dir = $SINCLAIR_DIR (exists=$([ -d "$SINCLAIR_DIR" ] && echo yes || echo no))"
 fi
 
 if [ -d "$TYPEBOX_DIR" ] && [ -d "$SINCLAIR_DIR" ]; then
   TYPEBOX_MAIN="$TYPEBOX_DIR/dist/esm/index.mjs"
+  echo "DEBUG: typebox main file = $TYPEBOX_MAIN (exists=$([ -f "$TYPEBOX_MAIN" ] && echo yes || echo no))"
   if [ -f "$TYPEBOX_MAIN" ] && ! grep -q 'export.*Type' "$TYPEBOX_MAIN" 2>/dev/null; then
     echo "INFO: Applying typebox compatibility workaround (symlinking @sinclair/typebox to typebox)..."
     rm -rf "$TYPEBOX_DIR"
     ln -s "$SINCLAIR_DIR" "$TYPEBOX_DIR"
+  else
+    echo "DEBUG: typebox main either missing or already exports Type — no workaround needed"
   fi
+else
+  echo "DEBUG: typebox or @sinclair/typebox directory not found — skipping workaround"
 fi
 
 if ! command -v openclaw >/dev/null 2>&1; then

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -59,6 +59,7 @@ FORCE_IPV4_DNS=$(jq -r '.force_ipv4_dns // true' "$OPTIONS_FILE")
 ACCESS_MODE=$(jq -r '.access_mode // "custom"' "$OPTIONS_FILE")
 NGINX_LOG_LEVEL=$(jq -r '.nginx_log_level // "minimal"' "$OPTIONS_FILE")
 AUTO_CONFIGURE_MCP=$(jq -r '.auto_configure_mcp // false' "$OPTIONS_FILE")
+AUTO_UPDATE=$(jq -r '.auto_update // false' "$OPTIONS_FILE")
 GW_ENV_VARS_TYPE=$(jq -r 'if .gateway_env_vars == null then "null" else (.gateway_env_vars | type) end' "$OPTIONS_FILE")
 GW_ENV_VARS_RAW=$(jq -r '.gateway_env_vars // empty' "$OPTIONS_FILE")
 GW_ENV_VARS_JSON=$(jq -c '.gateway_env_vars // []' "$OPTIONS_FILE")
@@ -508,15 +509,19 @@ shutdown() {
 
 trap shutdown INT TERM
 
-# Auto-update OpenClaw if a newer version is available on npm
-echo "INFO: Checking for OpenClaw updates..."
-INSTALLED_VER=$(openclaw --version 2>/dev/null | grep -oE '[0-9]{4}\.[0-9]+\.[0-9]+' | head -1 || echo "")
-LATEST_VER=$(npm view openclaw version 2>/dev/null || echo "")
-if [ -n "$LATEST_VER" ] && [ "$INSTALLED_VER" != "$LATEST_VER" ]; then
-  echo "INFO: Updating OpenClaw $INSTALLED_VER → $LATEST_VER"
-  npm install -g openclaw@latest 2>&1 || echo "WARN: Update failed, continuing with installed version"
+# Auto-update OpenClaw if enabled in add-on options and a newer version is available
+if [ "$AUTO_UPDATE" = "true" ]; then
+  echo "INFO: Auto-update enabled — checking for OpenClaw updates..."
+  INSTALLED_VER=$(openclaw --version 2>/dev/null | grep -oE '[0-9]{4}\.[0-9]+\.[0-9]+' | head -1 || echo "")
+  LATEST_VER=$(npm view openclaw version 2>/dev/null || echo "")
+  if [ -n "$LATEST_VER" ] && [ "$INSTALLED_VER" != "$LATEST_VER" ]; then
+    echo "INFO: Updating OpenClaw $INSTALLED_VER → $LATEST_VER"
+    npm install -g openclaw@latest 2>&1 || echo "WARN: Update failed, continuing with installed version"
+  else
+    echo "INFO: OpenClaw ${INSTALLED_VER:-unknown} is up to date"
+  fi
 else
-  echo "INFO: OpenClaw ${INSTALLED_VER:-unknown} is up to date"
+  echo "INFO: Auto-update disabled — skipping OpenClaw update check"
 fi
 
 if ! command -v openclaw >/dev/null 2>&1; then

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -519,23 +519,24 @@ if [ "$AUTO_UPDATE" = "true" ]; then
     # Clean up leftover npm temp directories that cause ENOTEMPTY on rename
     find "$(npm root -g)" -maxdepth 1 -name '.openclaw-*' -type d -exec rm -rf {} + 2>/dev/null || true
     npm install -g openclaw@latest 2>&1 || echo "WARN: Update failed, continuing with installed version"
-    # Workaround: OpenClaw 2026.4.22+ can have a typebox ESM interop issue where
-    # the bundled 'typebox' package does not re-export @sinclair/typebox correctly.
-    # If the 'typebox' module is missing the 'Type' export, symlink it to @sinclair/typebox.
-    OPENCLAW_GLOBAL_DIR="$(npm root -g)/openclaw"
-    if [ -d "$OPENCLAW_GLOBAL_DIR/node_modules/typebox" ] && [ -d "$OPENCLAW_GLOBAL_DIR/node_modules/@sinclair/typebox" ]; then
-      TYPEBOX_MAIN="$OPENCLAW_GLOBAL_DIR/node_modules/typebox/dist/esm/index.mjs"
-      if [ -f "$TYPEBOX_MAIN" ] && ! grep -q 'export.*Type' "$TYPEBOX_MAIN" 2>/dev/null; then
-        echo "INFO: Applying typebox compatibility workaround (symlinking @sinclair/typebox to typebox)..."
-        rm -rf "$OPENCLAW_GLOBAL_DIR/node_modules/typebox"
-        ln -s "$OPENCLAW_GLOBAL_DIR/node_modules/@sinclair/typebox" "$OPENCLAW_GLOBAL_DIR/node_modules/typebox"
-      fi
-    fi
   else
     echo "INFO: OpenClaw ${INSTALLED_VER:-unknown} is up to date"
   fi
 else
   echo "INFO: Auto-update disabled — skipping OpenClaw update check"
+fi
+
+# Workaround: OpenClaw 2026.4.22+ can have a typebox ESM interop issue where
+# the bundled 'typebox' package does not re-export @sinclair/typebox correctly.
+# If the 'typebox' module is missing the 'Type' export, symlink it to @sinclair/typebox.
+OPENCLAW_GLOBAL_DIR="$(npm root -g)/openclaw"
+if [ -d "$OPENCLAW_GLOBAL_DIR/node_modules/typebox" ] && [ -d "$OPENCLAW_GLOBAL_DIR/node_modules/@sinclair/typebox" ]; then
+  TYPEBOX_MAIN="$OPENCLAW_GLOBAL_DIR/node_modules/typebox/dist/esm/index.mjs"
+  if [ -f "$TYPEBOX_MAIN" ] && ! grep -q 'export.*Type' "$TYPEBOX_MAIN" 2>/dev/null; then
+    echo "INFO: Applying typebox compatibility workaround (symlinking @sinclair/typebox to typebox)..."
+    rm -rf "$OPENCLAW_GLOBAL_DIR/node_modules/typebox"
+    ln -s "$OPENCLAW_GLOBAL_DIR/node_modules/@sinclair/typebox" "$OPENCLAW_GLOBAL_DIR/node_modules/typebox"
+  fi
 fi
 
 if ! command -v openclaw >/dev/null 2>&1; then

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -519,6 +519,18 @@ if [ "$AUTO_UPDATE" = "true" ]; then
     # Clean up leftover npm temp directories that cause ENOTEMPTY on rename
     find "$(npm root -g)" -maxdepth 1 -name '.openclaw-*' -type d -exec rm -rf {} + 2>/dev/null || true
     npm install -g openclaw@latest 2>&1 || echo "WARN: Update failed, continuing with installed version"
+    # Workaround: OpenClaw 2026.4.22+ can have a typebox ESM interop issue where
+    # the bundled 'typebox' package does not re-export @sinclair/typebox correctly.
+    # If the 'typebox' module is missing the 'Type' export, symlink it to @sinclair/typebox.
+    OPENCLAW_GLOBAL_DIR="$(npm root -g)/openclaw"
+    if [ -d "$OPENCLAW_GLOBAL_DIR/node_modules/typebox" ] && [ -d "$OPENCLAW_GLOBAL_DIR/node_modules/@sinclair/typebox" ]; then
+      TYPEBOX_MAIN="$OPENCLAW_GLOBAL_DIR/node_modules/typebox/dist/esm/index.mjs"
+      if [ -f "$TYPEBOX_MAIN" ] && ! grep -q 'export.*Type' "$TYPEBOX_MAIN" 2>/dev/null; then
+        echo "INFO: Applying typebox compatibility workaround (symlinking @sinclair/typebox to typebox)..."
+        rm -rf "$OPENCLAW_GLOBAL_DIR/node_modules/typebox"
+        ln -s "$OPENCLAW_GLOBAL_DIR/node_modules/@sinclair/typebox" "$OPENCLAW_GLOBAL_DIR/node_modules/typebox"
+      fi
+    fi
   else
     echo "INFO: OpenClaw ${INSTALLED_VER:-unknown} is up to date"
   fi

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -529,13 +529,25 @@ fi
 # Workaround: OpenClaw 2026.4.22+ can have a typebox ESM interop issue where
 # the bundled 'typebox' package does not re-export @sinclair/typebox correctly.
 # If the 'typebox' module is missing the 'Type' export, symlink it to @sinclair/typebox.
-OPENCLAW_GLOBAL_DIR="$(npm root -g)/openclaw"
-if [ -d "$OPENCLAW_GLOBAL_DIR/node_modules/typebox" ] && [ -d "$OPENCLAW_GLOBAL_DIR/node_modules/@sinclair/typebox" ]; then
-  TYPEBOX_MAIN="$OPENCLAW_GLOBAL_DIR/node_modules/typebox/dist/esm/index.mjs"
+# NOTE: npm global installs hoist deps to the global root, so check there first.
+NPM_GLOBAL_ROOT="$(npm root -g)"
+TYPEBOX_DIR="$NPM_GLOBAL_ROOT/typebox"
+SINCLAIR_DIR="$NPM_GLOBAL_ROOT/@sinclair/typebox"
+
+# Fallback: some npm versions keep deps under the package's own node_modules
+if [ ! -d "$TYPEBOX_DIR" ]; then
+  TYPEBOX_DIR="$NPM_GLOBAL_ROOT/openclaw/node_modules/typebox"
+fi
+if [ ! -d "$SINCLAIR_DIR" ]; then
+  SINCLAIR_DIR="$NPM_GLOBAL_ROOT/openclaw/node_modules/@sinclair/typebox"
+fi
+
+if [ -d "$TYPEBOX_DIR" ] && [ -d "$SINCLAIR_DIR" ]; then
+  TYPEBOX_MAIN="$TYPEBOX_DIR/dist/esm/index.mjs"
   if [ -f "$TYPEBOX_MAIN" ] && ! grep -q 'export.*Type' "$TYPEBOX_MAIN" 2>/dev/null; then
     echo "INFO: Applying typebox compatibility workaround (symlinking @sinclair/typebox to typebox)..."
-    rm -rf "$OPENCLAW_GLOBAL_DIR/node_modules/typebox"
-    ln -s "$OPENCLAW_GLOBAL_DIR/node_modules/@sinclair/typebox" "$OPENCLAW_GLOBAL_DIR/node_modules/typebox"
+    rm -rf "$TYPEBOX_DIR"
+    ln -s "$SINCLAIR_DIR" "$TYPEBOX_DIR"
   fi
 fi
 

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -508,6 +508,17 @@ shutdown() {
 
 trap shutdown INT TERM
 
+# Auto-update OpenClaw if a newer version is available on npm
+echo "INFO: Checking for OpenClaw updates..."
+INSTALLED_VER=$(openclaw --version 2>/dev/null | grep -oE '[0-9]{4}\.[0-9]+\.[0-9]+' | head -1 || echo "")
+LATEST_VER=$(npm view openclaw version 2>/dev/null || echo "")
+if [ -n "$LATEST_VER" ] && [ "$INSTALLED_VER" != "$LATEST_VER" ]; then
+  echo "INFO: Updating OpenClaw $INSTALLED_VER → $LATEST_VER"
+  npm install -g openclaw@latest 2>&1 || echo "WARN: Update failed, continuing with installed version"
+else
+  echo "INFO: OpenClaw ${INSTALLED_VER:-unknown} is up to date"
+fi
+
 if ! command -v openclaw >/dev/null 2>&1; then
   echo "ERROR: openclaw is not installed."
   exit 1
@@ -770,6 +781,13 @@ elif [ "$AUTO_CONFIGURE_MCP" = "true" ] && [ -z "$HA_TOKEN" ]; then
 fi
 
 start_openclaw_runtime() {
+  # Auto-fix legacy config keys that block startup after version upgrades
+  # (e.g. tools.web.search → plugins.entries.<plugin>.config.webSearch)
+  if openclaw doctor 2>&1 | grep -q "Legacy config\|Config invalid"; then
+    echo "INFO: Detected legacy config keys — running 'openclaw doctor --fix'..."
+    openclaw doctor --fix 2>&1 || echo "WARN: 'openclaw doctor --fix' exited with non-zero status"
+  fi
+
   echo "Starting OpenClaw Assistant runtime (openclaw)..."
   if [ "$GATEWAY_MODE" = "remote" ]; then
     # Remote mode: do NOT start a local gateway service.

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -526,38 +526,27 @@ else
   echo "INFO: Auto-update disabled — skipping OpenClaw update check"
 fi
 
-# Workaround: OpenClaw 2026.4.22+ can have a typebox ESM interop issue where
-# the bundled 'typebox' package does not re-export @sinclair/typebox correctly.
-# If the 'typebox' module is missing the 'Type' export, symlink it to @sinclair/typebox.
-# NOTE: npm global installs hoist deps to the global root, so check there first.
+# Workaround: OpenClaw 2026.4.22+ bundles a broken 'typebox' package that
+# fails to re-export @sinclair/typebox. The bundled package exists but
+# @sinclair/typebox itself may not be installed. Install it and symlink.
 NPM_GLOBAL_ROOT="$(npm root -g)"
-echo "DEBUG: npm root -g = $NPM_GLOBAL_ROOT"
-TYPEBOX_DIR="$NPM_GLOBAL_ROOT/typebox"
+TYPEBOX_DIR="$NPM_GLOBAL_ROOT/openclaw/node_modules/typebox"
 SINCLAIR_DIR="$NPM_GLOBAL_ROOT/@sinclair/typebox"
-echo "DEBUG: typebox dir (hoisted) = $TYPEBOX_DIR (exists=$([ -d "$TYPEBOX_DIR" ] && echo yes || echo no))"
-echo "DEBUG: @sinclair/typebox dir (hoisted) = $SINCLAIR_DIR (exists=$([ -d "$SINCLAIR_DIR" ] && echo yes || echo no))"
 
-# Fallback: some npm versions keep deps under the package's own node_modules
-if [ ! -d "$TYPEBOX_DIR" ]; then
-  TYPEBOX_DIR="$NPM_GLOBAL_ROOT/openclaw/node_modules/typebox"
-  echo "DEBUG: falling back to nested typebox dir = $TYPEBOX_DIR (exists=$([ -d "$TYPEBOX_DIR" ] && echo yes || echo no))"
-fi
-if [ ! -d "$SINCLAIR_DIR" ]; then
-  SINCLAIR_DIR="$NPM_GLOBAL_ROOT/openclaw/node_modules/@sinclair/typebox"
-  echo "DEBUG: falling back to nested @sinclair/typebox dir = $SINCLAIR_DIR (exists=$([ -d "$SINCLAIR_DIR" ] && echo yes || echo no))"
-fi
-
-if [ -d "$TYPEBOX_DIR" ] && [ -d "$SINCLAIR_DIR" ]; then
+if [ -d "$TYPEBOX_DIR" ]; then
   TYPEBOX_MAIN="$TYPEBOX_DIR/dist/esm/index.mjs"
-  echo "DEBUG: typebox main file = $TYPEBOX_MAIN (exists=$([ -f "$TYPEBOX_MAIN" ] && echo yes || echo no))"
   if [ -f "$TYPEBOX_MAIN" ] && ! grep -q 'export.*Type' "$TYPEBOX_MAIN" 2>/dev/null; then
-    echo "INFO: Applying typebox compatibility workaround (symlinking @sinclair/typebox to typebox)..."
-    rm -rf "$TYPEBOX_DIR"
-    ln -s "$SINCLAIR_DIR" "$TYPEBOX_DIR"
-  else
-    echo "DEBUG: typebox main either missing or already exports Type — no workaround needed"
+    echo "INFO: Bundled typebox is missing Type export. Installing @sinclair/typebox..."
+    npm install -g @sinclair/typebox@latest 2>&1 || true
+    if [ -d "$SINCLAIR_DIR" ]; then
+      echo "INFO: Symlinking @sinclair/typebox in place of broken typebox..."
+      rm -rf "$TYPEBOX_DIR"
+      ln -s "$SINCLAIR_DIR" "$TYPEBOX_DIR"
+    else
+      echo "WARN: @sinclair/typebox installation failed; workaround incomplete"
+    fi
   fi
-else
+fi
   echo "DEBUG: typebox or @sinclair/typebox directory not found — skipping workaround"
 fi
 

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -558,8 +558,53 @@ if [ -d "$TYPEBOX_DIR" ]; then
       echo "WARN: @sinclair/typebox installation failed; workaround incomplete"
     fi
   fi
-fi
+else
   echo "DEBUG: typebox or @sinclair/typebox directory not found — skipping workaround"
+fi
+
+# Workaround: OpenClaw 2026.4.22+ may bundle a broken '@modelcontextprotocol/sdk'
+# package with an invalid package.json that Node rejects with
+# ERR_INVALID_PACKAGE_CONFIG, preventing the gateway from starting. Detect by
+# attempting the exact import openclaw performs; if it fails, install a fresh
+# copy globally and symlink it into openclaw's node_modules.
+MCP_SDK_DIR="$NPM_GLOBAL_ROOT/openclaw/node_modules/@modelcontextprotocol/sdk"
+MCP_SDK_GLOBAL="$NPM_GLOBAL_ROOT/@modelcontextprotocol/sdk"
+OPENCLAW_PKG="$NPM_GLOBAL_ROOT/openclaw/package.json"
+
+if [ -d "$MCP_SDK_DIR" ]; then
+  MCP_SDK_BROKEN=1
+  # Quick check: bundled package.json must be parseable JSON.
+  if jq -e . "$MCP_SDK_DIR/package.json" >/dev/null 2>&1; then
+    # Deeper check: run the exact ESM import from inside openclaw so Node resolves
+    # via openclaw's node_modules. A clean exit means the package is healthy.
+    if (cd "$NPM_GLOBAL_ROOT/openclaw" && node --input-type=module -e \
+        "import('@modelcontextprotocol/sdk/client/index.js').then(()=>process.exit(0)).catch(()=>process.exit(1))" \
+        >/dev/null 2>&1); then
+      MCP_SDK_BROKEN=0
+    fi
+  fi
+  if [ "$MCP_SDK_BROKEN" = "1" ]; then
+    echo "INFO: Bundled @modelcontextprotocol/sdk is broken. Installing fresh copy..."
+    # Prefer the version openclaw actually depends on; fall back to latest.
+    EXPECTED_MCP_VER=""
+    if [ -f "$OPENCLAW_PKG" ]; then
+      EXPECTED_MCP_VER=$(jq -r '(.dependencies["@modelcontextprotocol/sdk"] // .devDependencies["@modelcontextprotocol/sdk"] // .optionalDependencies["@modelcontextprotocol/sdk"] // empty)' "$OPENCLAW_PKG" 2>/dev/null || true)
+    fi
+    if [ -n "$EXPECTED_MCP_VER" ]; then
+      npm install -g "@modelcontextprotocol/sdk@${EXPECTED_MCP_VER}" 2>&1 || \
+        npm install -g "@modelcontextprotocol/sdk@latest" 2>&1 || true
+    else
+      npm install -g "@modelcontextprotocol/sdk@latest" 2>&1 || true
+    fi
+    if [ -d "$MCP_SDK_GLOBAL" ]; then
+      echo "INFO: Symlinking @modelcontextprotocol/sdk in place of broken bundled version..."
+      rm -rf "$MCP_SDK_DIR"
+      mkdir -p "$(dirname "$MCP_SDK_DIR")"
+      ln -s "$MCP_SDK_GLOBAL" "$MCP_SDK_DIR"
+    else
+      echo "WARN: @modelcontextprotocol/sdk installation failed; workaround incomplete"
+    fi
+  fi
 fi
 
 if ! command -v openclaw >/dev/null 2>&1; then

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -526,36 +526,46 @@ else
   echo "INFO: Auto-update disabled — skipping OpenClaw update check"
 fi
 
-# Workaround: OpenClaw 2026.4.22+ bundles a broken 'typebox' package that
-# fails to re-export @sinclair/typebox. The bundled package exists but
-# @sinclair/typebox itself may not be installed. Install it and symlink.
+# Workaround: OpenClaw 2026.4.22+ bundles a broken 'typebox' npm package.
+# The bundled copy both misses the top-level `Type` export and fails to
+# resolve subpaths like `typebox/compile`. Reinstall a clean copy of the
+# SAME `typebox` package from npm (preferring the version openclaw pins)
+# and symlink it in place of the broken bundle. We no longer substitute
+# @sinclair/typebox — its subpath layout (./compiler, ./value) is
+# incompatible with what openclaw's deps (e.g. @mariozechner/pi-coding-agent)
+# import (./compile).
 NPM_GLOBAL_ROOT="$(npm root -g)"
 TYPEBOX_DIR="$NPM_GLOBAL_ROOT/openclaw/node_modules/typebox"
-SINCLAIR_DIR="$NPM_GLOBAL_ROOT/@sinclair/typebox"
+TYPEBOX_GLOBAL="$NPM_GLOBAL_ROOT/typebox"
+OPENCLAW_PKG_EARLY="$NPM_GLOBAL_ROOT/openclaw/package.json"
 
-if [ -d "$TYPEBOX_DIR" ]; then
-  # Discover the actual module entry point from package.json (module > main)
-  TYPEBOX_MAIN=""
-  TYPEBOX_PKG="$TYPEBOX_DIR/package.json"
-  if [ -f "$TYPEBOX_PKG" ]; then
-    TYPEBOX_MAIN=$(jq -r 'if .module then (.module | sub("^\\./"; "")) elif .main then (.main | sub("^\\./"; "")) else empty end' "$TYPEBOX_PKG")
-    if [ -n "$TYPEBOX_MAIN" ]; then
-      TYPEBOX_MAIN="$TYPEBOX_DIR/$TYPEBOX_MAIN"
+if [ -e "$TYPEBOX_DIR" ]; then
+  TYPEBOX_BROKEN=1
+  # Probe actual usage: both top-level Type export and the ./compile subpath
+  # must resolve. A clean exit means the package is healthy.
+  if (cd "$NPM_GLOBAL_ROOT/openclaw" && node --input-type=module -e \
+      "Promise.all([import('typebox').then(m=>{if(!m.Type)throw new Error('no Type')}),import('typebox/compile')]).then(()=>process.exit(0)).catch(()=>process.exit(1))" \
+      >/dev/null 2>&1); then
+    TYPEBOX_BROKEN=0
+  fi
+  if [ "$TYPEBOX_BROKEN" = "1" ]; then
+    echo "INFO: Bundled typebox is broken (missing Type export and/or ./compile subpath). Installing fresh copy..."
+    EXPECTED_TYPEBOX_VER=""
+    if [ -f "$OPENCLAW_PKG_EARLY" ]; then
+      EXPECTED_TYPEBOX_VER=$(jq -r '(.dependencies.typebox // .devDependencies.typebox // .optionalDependencies.typebox // empty)' "$OPENCLAW_PKG_EARLY" 2>/dev/null || true)
     fi
-  fi
-  # Fallback for legacy layouts
-  if [ -z "$TYPEBOX_MAIN" ] || [ ! -f "$TYPEBOX_MAIN" ]; then
-    TYPEBOX_MAIN="$TYPEBOX_DIR/dist/esm/index.mjs"
-  fi
-  if [ -f "$TYPEBOX_MAIN" ] && ! grep -q 'export.*Type' "$TYPEBOX_MAIN" 2>/dev/null; then
-    echo "INFO: Bundled typebox is missing Type export. Installing @sinclair/typebox..."
-    npm install -g @sinclair/typebox@latest 2>&1 || true
-    if [ -d "$SINCLAIR_DIR" ]; then
-      echo "INFO: Symlinking @sinclair/typebox in place of broken typebox..."
-      rm -rf "$TYPEBOX_DIR"
-      ln -s "$SINCLAIR_DIR" "$TYPEBOX_DIR"
+    if [ -n "$EXPECTED_TYPEBOX_VER" ]; then
+      npm install -g "typebox@${EXPECTED_TYPEBOX_VER}" 2>&1 || \
+        npm install -g "typebox@latest" 2>&1 || true
     else
-      echo "WARN: @sinclair/typebox installation failed; workaround incomplete"
+      npm install -g "typebox@latest" 2>&1 || true
+    fi
+    if [ -d "$TYPEBOX_GLOBAL" ]; then
+      echo "INFO: Symlinking fresh typebox in place of broken bundled version..."
+      rm -rf "$TYPEBOX_DIR"
+      ln -s "$TYPEBOX_GLOBAL" "$TYPEBOX_DIR"
+    else
+      echo "WARN: typebox installation failed; workaround incomplete"
     fi
   fi
 else

--- a/openclaw_assistant/translations/bg.yaml
+++ b/openclaw_assistant/translations/bg.yaml
@@ -113,3 +113,6 @@ configuration:
   auto_configure_mcp:
     name: Автоматично конфигуриране на MCP за Home Assistant
     description: "Когато е ВКЛ. и Home Assistant Token е зададен, автоматично регистрира Home Assistant като MCP сървър при всяко стартиране. Това позволява на OpenClaw да контролира HA устройства, услуги и автоматизации чрез Model Context Protocol. Изключете само ако управлявате mcporter конфигурацията ръчно."
+  auto_update:
+    name: Автоматично обновяване на OpenClaw при стартиране
+    description: "Когато е ВКЛ., автоматично проверява и инсталира последната версия на OpenClaw от npm при всяко стартиране на добавката. Когато е ИЗКЛ. (по подразбиране), OpenClaw се обновява само при rebuild на добавката."

--- a/openclaw_assistant/translations/de.yaml
+++ b/openclaw_assistant/translations/de.yaml
@@ -113,3 +113,6 @@ configuration:
   auto_configure_mcp:
     name: MCP für Home Assistant automatisch konfigurieren
     description: "Wenn AN und Home Assistant Token gesetzt ist, wird Home Assistant bei jedem Start automatisch als MCP-Server registriert. Das erlaubt OpenClaw, HA-Geräte, -Dienste und -Automatisierungen über das Model Context Protocol zu steuern. Nur deaktivieren, wenn Sie die mcporter-Konfiguration manuell verwalten."
+  auto_update:
+    name: OpenClaw beim Start automatisch aktualisieren
+    description: "Wenn AN, wird bei jedem Start des Add-ons automatisch die neueste OpenClaw-Version von npm geprüft und installiert. Wenn AUS (Standard), wird OpenClaw nur beim Rebuild des Add-ons aktualisiert."

--- a/openclaw_assistant/translations/en.yaml
+++ b/openclaw_assistant/translations/en.yaml
@@ -113,3 +113,6 @@ configuration:
   auto_configure_mcp:
     name: Auto-Configure MCP for Home Assistant
     description: "When ON and Home Assistant Token is set, automatically registers Home Assistant as an MCP server on each startup. This lets OpenClaw control HA entities, services, and automations via the Model Context Protocol. Disable only if you manage mcporter configuration manually."
+  auto_update:
+    name: Auto-Update OpenClaw on Startup
+    description: "When ON, automatically checks for and installs the latest OpenClaw version from npm each time the add-on starts. When OFF (default), OpenClaw is only updated when you rebuild the add-on."

--- a/openclaw_assistant/translations/es.yaml
+++ b/openclaw_assistant/translations/es.yaml
@@ -113,3 +113,6 @@ configuration:
   auto_configure_mcp:
     name: Configurar MCP automáticamente para Home Assistant
     description: "Cuando está ACTIVADO y el token de Home Assistant está configurado, registra automáticamente Home Assistant como servidor MCP en cada inicio. Esto permite a OpenClaw controlar entidades, servicios y automatizaciones de HA mediante el Model Context Protocol. Desactive solo si administra la configuración de mcporter manualmente."
+  auto_update:
+    name: Actualizar OpenClaw automáticamente al iniciar
+    description: "Cuando está ACTIVADO, comprueba e instala automáticamente la última versión de OpenClaw desde npm cada vez que se inicia el complemento. Cuando está DESACTIVADO (por defecto), OpenClaw solo se actualiza al reconstruir el complemento."

--- a/openclaw_assistant/translations/pl.yaml
+++ b/openclaw_assistant/translations/pl.yaml
@@ -113,3 +113,6 @@ configuration:
   auto_configure_mcp:
     name: Automatyczna konfiguracja MCP dla Home Assistant
     description: "Gdy WŁĄCZONE i token Home Assistant jest ustawiony, automatycznie rejestruje Home Assistant jako serwer MCP przy każdym starcie. Pozwala to OpenClaw kontrolować urządzenia HA, usługi i automatyzacje przez Model Context Protocol. Wyłącz tylko jeśli zarządzasz konfiguracją mcporter ręcznie."
+  auto_update:
+    name: Automatyczna aktualizacja OpenClaw przy starcie
+    description: "Gdy WŁĄCZONE, automatycznie sprawdza i instaluje najnowszą wersję OpenClaw z npm przy każdym uruchomieniu dodatku. Gdy WYŁĄCZONE (domyślnie), OpenClaw jest aktualizowany tylko przy przebudowie dodatku."

--- a/openclaw_assistant/translations/pt-BR.yaml
+++ b/openclaw_assistant/translations/pt-BR.yaml
@@ -113,3 +113,6 @@ configuration:
   auto_configure_mcp:
     name: Configurar MCP automaticamente para o Home Assistant
     description: "Quando LIGADO e o token do Home Assistant estiver definido, registra automaticamente o Home Assistant como servidor MCP a cada inicialização. Isso permite que o OpenClaw controle entidades, serviços e automações do HA via Model Context Protocol. Desative apenas se você gerencia a configuração do mcporter manualmente."
+  auto_update:
+    name: Atualizar OpenClaw automaticamente na inicialização
+    description: "Quando LIGADO, verifica e instala automaticamente a versão mais recente do OpenClaw do npm a cada inicialização do complemento. Quando DESLIGADO (padrão), o OpenClaw só é atualizado ao reconstruir o complemento."


### PR DESCRIPTION
# Summary

  - Add automatic OpenClaw version check and update on add-on startup. Restarting the add-on will automatically update OpenClaw to the latest version if a newer one is available.
  - Add openclaw doctor --fix step before runtime launch to auto-fix legacy config keys that may break after version upgrades.

# Background

Previously, updating OpenClaw required manually updating the add-on image. With this change, simply restarting the add-on triggers an automatic update via npm — no rebuild needed.

After a version upgrade, certain config keys may become invalid or renamed. The openclaw doctor --fix step detects and corrects these legacy config issues before the runtime starts, preventing startup failures.

# Testing

  Verified stability across two consecutive automatic upgrades:
  - 2026.4.2 → 2026.4.5
  - 2026.4.5 → 2026.4.8

  Both upgrades completed successfully on restart with no manual intervention. The doctor fix step correctly handled config key migrations in each case.