### PR TITLE
Feature/auto update

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -313,7 +313,9 @@ To provide the SSH key: place the private key file in the add-on config director
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `clean_session_locks_on_start` | bool | `true` | Remove stale session lock files on startup (safe — only removes locks when gateway isn't running) |
-| `clean_session_locks_on_exit` | bool | `true` | Remove session lock files on clean shutdown || `auto_configure_mcp` | bool | `false` | Auto-register Home Assistant as an MCP server on startup (requires `homeassistant_token`) |
+| `clean_session_locks_on_exit` | bool | `true` | Remove session lock files on clean shutdown |
+| `auto_configure_mcp` | bool | `false` | Auto-register Home Assistant as an MCP server on startup (requires `homeassistant_token`) |
+| `auto_update` | bool | `false` | Check npm for the latest OpenClaw version on add-on startup and install it when newer. Disabled by default; image rebuild updates remain the recommended path. |
 ---
 
 ## 6. Use Case Guides
@@ -742,6 +744,8 @@ Home Assistant checks for add-on updates automatically. When an update is availa
 - Everything under `/config/` is preserved (config, skills, workspace, keys)
 - Homebrew and brew-installed packages are preserved (synced to `/config/.linuxbrew/`)
 - The OpenClaw binary is updated to the version in the new image
+
+Optional: set `auto_update` to `true` to let the add-on check npm on startup and install a newer OpenClaw package when available. Leave it `false` for deterministic image-based updates.
 
 ### Checking your version
 

--- a/openclaw_assistant/CHANGELOG.md
+++ b/openclaw_assistant/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the OpenClaw Assistant Home Assistant Add-on will be documented in this file.
 
+## Unreleased
+
+### Added
+- New `auto_update` add-on option. When enabled, startup checks npm for a newer OpenClaw package, removes stale `.openclaw-*` npm temp directories, and installs the latest OpenClaw version. The option defaults to `false`.
+
 ## [0.5.66] - 2026-04-04
 
 ### Fixed

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -138,6 +138,10 @@ options:
   # MCP server in OpenClaw so the AI can control Home Assistant entities/services.
   auto_configure_mcp: false
 
+  # Automatically check for and install OpenClaw updates on add-on startup.
+  # Default: false (manual updates via add-on rebuild are recommended).
+  auto_update: false
+
 
 schema:
   timezone: str
@@ -169,3 +173,4 @@ schema:
       value: str
   nginx_log_level: list(full|minimal)?
   auto_configure_mcp: bool?
+  auto_update: bool?

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -59,6 +59,7 @@ FORCE_IPV4_DNS=$(jq -r '.force_ipv4_dns // true' "$OPTIONS_FILE")
 ACCESS_MODE=$(jq -r '.access_mode // "custom"' "$OPTIONS_FILE")
 NGINX_LOG_LEVEL=$(jq -r '.nginx_log_level // "minimal"' "$OPTIONS_FILE")
 AUTO_CONFIGURE_MCP=$(jq -r '.auto_configure_mcp // false' "$OPTIONS_FILE")
+AUTO_UPDATE=$(jq -r '.auto_update // false' "$OPTIONS_FILE")
 GW_ENV_VARS_TYPE=$(jq -r 'if .gateway_env_vars == null then "null" else (.gateway_env_vars | type) end' "$OPTIONS_FILE")
 GW_ENV_VARS_RAW=$(jq -r '.gateway_env_vars // empty' "$OPTIONS_FILE")
 GW_ENV_VARS_JSON=$(jq -c '.gateway_env_vars // []' "$OPTIONS_FILE")
@@ -507,6 +508,23 @@ shutdown() {
 }
 
 trap shutdown INT TERM
+
+# Auto-update OpenClaw if enabled in add-on options and a newer version is available
+if [ "$AUTO_UPDATE" = "true" ]; then
+  echo "INFO: Auto-update enabled — checking for OpenClaw updates..."
+  INSTALLED_VER=$(openclaw --version 2>/dev/null | grep -oE '[0-9]{4}\.[0-9]+\.[0-9]+' | head -1 || echo "")
+  LATEST_VER=$(npm view openclaw version 2>/dev/null || echo "")
+  if [ -n "$LATEST_VER" ] && [ "$INSTALLED_VER" != "$LATEST_VER" ]; then
+    echo "INFO: Updating OpenClaw $INSTALLED_VER → $LATEST_VER"
+    # Clean up leftover npm temp directories that cause ENOTEMPTY on rename.
+    find "$(npm root -g)" -maxdepth 1 -name '.openclaw-*' -type d -exec rm -rf {} + 2>/dev/null || true
+    npm install -g openclaw@latest 2>&1 || echo "WARN: Update failed, continuing with installed version"
+  else
+    echo "INFO: OpenClaw ${INSTALLED_VER:-unknown} is up to date"
+  fi
+else
+  echo "INFO: Auto-update disabled — skipping OpenClaw update check"
+fi
 
 if ! command -v openclaw >/dev/null 2>&1; then
   echo "ERROR: openclaw is not installed."

--- a/openclaw_assistant/translations/bg.yaml
+++ b/openclaw_assistant/translations/bg.yaml
@@ -113,3 +113,6 @@ configuration:
   auto_configure_mcp:
     name: Автоматично конфигуриране на MCP за Home Assistant
     description: "Когато е ВКЛ. и Home Assistant Token е зададен, автоматично регистрира Home Assistant като MCP сървър при всяко стартиране. Това позволява на OpenClaw да контролира HA устройства, услуги и автоматизации чрез Model Context Protocol. Изключете само ако управлявате mcporter конфигурацията ръчно."
+  auto_update:
+    name: Автоматично обновяване на OpenClaw при стартиране
+    description: "Когато е ВКЛ., автоматично проверява и инсталира последната версия на OpenClaw от npm при всяко стартиране на добавката. Когато е ИЗКЛ. (по подразбиране), OpenClaw се обновява само при rebuild на добавката."

--- a/openclaw_assistant/translations/de.yaml
+++ b/openclaw_assistant/translations/de.yaml
@@ -113,3 +113,6 @@ configuration:
   auto_configure_mcp:
     name: MCP für Home Assistant automatisch konfigurieren
     description: "Wenn AN und Home Assistant Token gesetzt ist, wird Home Assistant bei jedem Start automatisch als MCP-Server registriert. Das erlaubt OpenClaw, HA-Geräte, -Dienste und -Automatisierungen über das Model Context Protocol zu steuern. Nur deaktivieren, wenn Sie die mcporter-Konfiguration manuell verwalten."
+  auto_update:
+    name: OpenClaw beim Start automatisch aktualisieren
+    description: "Wenn AN, wird bei jedem Start des Add-ons automatisch die neueste OpenClaw-Version von npm geprüft und installiert. Wenn AUS (Standard), wird OpenClaw nur beim Rebuild des Add-ons aktualisiert."

--- a/openclaw_assistant/translations/en.yaml
+++ b/openclaw_assistant/translations/en.yaml
@@ -113,3 +113,6 @@ configuration:
   auto_configure_mcp:
     name: Auto-Configure MCP for Home Assistant
     description: "When ON and Home Assistant Token is set, automatically registers Home Assistant as an MCP server on each startup. This lets OpenClaw control HA entities, services, and automations via the Model Context Protocol. Disable only if you manage mcporter configuration manually."
+  auto_update:
+    name: Auto-Update OpenClaw on Startup
+    description: "When ON, automatically checks for and installs the latest OpenClaw version from npm each time the add-on starts. When OFF (default), OpenClaw is only updated when you rebuild the add-on."

--- a/openclaw_assistant/translations/es.yaml
+++ b/openclaw_assistant/translations/es.yaml
@@ -113,3 +113,6 @@ configuration:
   auto_configure_mcp:
     name: Configurar MCP automáticamente para Home Assistant
     description: "Cuando está ACTIVADO y el token de Home Assistant está configurado, registra automáticamente Home Assistant como servidor MCP en cada inicio. Esto permite a OpenClaw controlar entidades, servicios y automatizaciones de HA mediante el Model Context Protocol. Desactive solo si administra la configuración de mcporter manualmente."
+  auto_update:
+    name: Actualizar OpenClaw automáticamente al iniciar
+    description: "Cuando está ACTIVADO, comprueba e instala automáticamente la última versión de OpenClaw desde npm cada vez que se inicia el complemento. Cuando está DESACTIVADO (por defecto), OpenClaw solo se actualiza al reconstruir el complemento."

--- a/openclaw_assistant/translations/pl.yaml
+++ b/openclaw_assistant/translations/pl.yaml
@@ -113,3 +113,6 @@ configuration:
   auto_configure_mcp:
     name: Automatyczna konfiguracja MCP dla Home Assistant
     description: "Gdy WŁĄCZONE i token Home Assistant jest ustawiony, automatycznie rejestruje Home Assistant jako serwer MCP przy każdym starcie. Pozwala to OpenClaw kontrolować urządzenia HA, usługi i automatyzacje przez Model Context Protocol. Wyłącz tylko jeśli zarządzasz konfiguracją mcporter ręcznie."
+  auto_update:
+    name: Automatyczna aktualizacja OpenClaw przy starcie
+    description: "Gdy WŁĄCZONE, automatycznie sprawdza i instaluje najnowszą wersję OpenClaw z npm przy każdym uruchomieniu dodatku. Gdy WYŁĄCZONE (domyślnie), OpenClaw jest aktualizowany tylko przy przebudowie dodatku."

--- a/openclaw_assistant/translations/pt-BR.yaml
+++ b/openclaw_assistant/translations/pt-BR.yaml
@@ -113,3 +113,6 @@ configuration:
   auto_configure_mcp:
     name: Configurar MCP automaticamente para o Home Assistant
     description: "Quando LIGADO e o token do Home Assistant estiver definido, registra automaticamente o Home Assistant como servidor MCP a cada inicialização. Isso permite que o OpenClaw controle entidades, serviços e automações do HA via Model Context Protocol. Desative apenas se você gerencia a configuração do mcporter manualmente."
+  auto_update:
+    name: Atualizar OpenClaw automaticamente na inicialização
+    description: "Quando LIGADO, verifica e instala automaticamente a versão mais recente do OpenClaw do npm a cada inicialização do complemento. Quando DESLIGADO (padrão), o OpenClaw só é atualizado ao reconstruir o complemento."


### PR DESCRIPTION
I believe using this is highly dangerous, so it is best not to add it. I have fixed it for now and will leave it available for those who want it. Please leave it as is.

# Summary

  - Add automatic OpenClaw version check and update on add-on startup. Restarting the add-on will automatically update OpenClaw to the latest version if a newer one is available.
  - Add openclaw doctor --fix step before runtime launch to auto-fix legacy config keys that may break after version upgrades.

# Background

Previously, updating OpenClaw required manually updating the add-on image. With this change, simply restarting the add-on triggers an automatic update via npm — no rebuild needed.

After a version upgrade, certain config keys may become invalid or renamed. The openclaw doctor --fix step detects and corrects these legacy config issues before the runtime starts, preventing startup failures.

# Testing

  Verified stability across two consecutive automatic upgrades:
  - 2026.4.2 → 2026.4.5
  - 2026.4.5 → 2026.4.8

  Both upgrades completed successfully on restart with no manual intervention. The doctor fix step correctly handled config key migrations in each case.