### PR TITLE
Bump OpenClaw to 2026.6.8

### DIFF
--- a/openclaw_assistant/Dockerfile
+++ b/openclaw_assistant/Dockerfile
@@ -117,7 +117,7 @@ USER root
 # Bundle node-llama-cpp in the image so the default local memory/embeddings
 # provider works in HAOS without requiring manual npm installs in /usr/lib.
 RUN npm config set fund false && npm config set audit false \
-    && npm install -g openclaw@2026.6.6 node-llama-cpp@3.18.1
+    && npm install -g openclaw@2026.6.8 node-llama-cpp@3.18.1
 
 # Shell aliases and color options for interactive use
 RUN tee -a /etc/bash.bashrc <<'EOF'

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.78"
+version: "0.5.79"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant


### PR DESCRIPTION
Automated update:
- openclaw_assistant/Dockerfile: openclaw@2026.6.6 → openclaw@2026.6.8
- openclaw_assistant/config.yaml: add-on version 0.5.78 → 0.5.79

By OpenClaw Home Assistant Bot.