### PR TITLE
fix(addon): bundle mcporter for HA MCP auto-config

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -497,7 +497,7 @@ The **Model Context Protocol (MCP)** lets OpenClaw communicate directly with Hom
 3. Set **Auto-Configure MCP for Home Assistant** (`auto_configure_mcp`) to **ON**
 4. Restart the add-on
 
-The add-on will automatically register Home Assistant as an MCP server named `HA` using `mcporter`. It auto-detects the HA API URL (supervisor proxy when available, otherwise `localhost:8123`). Check the logs for:
+The add-on bundles `mcporter` and automatically registers Home Assistant as an MCP server named `HA`. It auto-detects the HA API URL (supervisor proxy when available, otherwise `localhost:8123`). Check the logs for:
 ```
 INFO: MCP server 'HA' registered — OpenClaw can now control Home Assistant
 ```
@@ -543,7 +543,7 @@ MCP setup requires an AI model that understands tool/skill invocation. Budget mo
 
 | Symptom | Fix |
 |---|---|
-| `mcporter: command not found` | Run `openclaw onboard` first, then restart the add-on |
+| `mcporter: command not found` | Upgrade to add-on `0.5.83` or newer. Older builds did not bundle `mcporter`; as a temporary workaround, install it manually in the add-on terminal and restart. |
 | MCP add fails with auth error | Verify your long-lived token is valid and not expired |
 | OpenClaw doesn’t see HA entities | Run `mcporter call home-assistant.GetLiveContext` to refresh |
 | Model says “what’s MCP?” | Switch to a more capable model for the initial session (see above) |

--- a/openclaw_assistant/CHANGELOG.md
+++ b/openclaw_assistant/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the OpenClaw Assistant Home Assistant Add-on will be documented in this file.
 
+## [0.5.83] - 2026-07-16
+
+### Fixed
+- Bundle a Node 22-compatible `mcporter` CLI in the add-on image so `auto_configure_mcp` can register Home Assistant out of the box on fresh installs, without requiring a manual `npm install -g mcporter` workaround.
+- Replace the misleading startup hint that told users to run `openclaw onboard` when `mcporter` was missing. That message now correctly points to a broken image state instead of a required onboarding step.
+
 ## [0.5.82] - 2026-07-15
 
 ### Fixed

--- a/openclaw_assistant/Dockerfile
+++ b/openclaw_assistant/Dockerfile
@@ -113,11 +113,13 @@ RUN if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then \
     fi
 USER root
 
-# Install OpenClaw globally
-# Bundle node-llama-cpp in the image so the default local memory/embeddings
-# provider works in HAOS without requiring manual npm installs in /usr/lib.
+# Install OpenClaw globally.
+# Bundle node-llama-cpp so the default local memory/embeddings provider works
+# in HAOS without requiring manual npm installs in /usr/lib.
+# Bundle mcporter so Home Assistant MCP auto-configuration works out of the box.
+# mcporter 0.9.0 is the newest release that supports the add-on's Node 22 base.
 RUN npm config set fund false && npm config set audit false \
-    && npm install -g openclaw@2026.7.1 node-llama-cpp@3.18.1
+    && npm install -g openclaw@2026.7.1 node-llama-cpp@3.18.1 mcporter@0.9.0
 
 # Shell aliases and color options for interactive use
 RUN tee -a /etc/bash.bashrc <<'EOF'

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.82"
+version: "0.5.83"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -920,7 +920,7 @@ if [ "$AUTO_CONFIGURE_MCP" = "true" ] && [ -n "$HA_TOKEN" ]; then
       fi
     fi
   else
-    echo "INFO: mcporter not available; skipping MCP auto-configuration (run 'openclaw onboard' first)"
+    echo "WARN: mcporter is missing from the add-on image; skipping MCP auto-configuration"
   fi
 elif [ "$AUTO_CONFIGURE_MCP" = "true" ] && [ -z "$HA_TOKEN" ]; then
   echo "INFO: MCP auto-configure enabled but homeassistant_token not set — skipping"


### PR DESCRIPTION
## Summary
- bundle a Node 22-compatible `mcporter` CLI in the add-on image so Home Assistant MCP auto-configuration works on fresh installs
- update the missing-`mcporter` startup warning and MCP docs to reflect that this is an image packaging issue, not a required `openclaw onboard` step
- bump the add-on version to `0.5.83`

## Verification
- `bash -n openclaw_assistant/run.sh`
- `git diff --check`
- `npm install --prefix "$TMPDIR" mcporter@0.9.0` smoke test on Node `v22.22.3`, followed by `mcporter config --help`

## Notes
- `mcporter@0.9.0` is pinned intentionally because the newer `0.10.x+` releases require Node `>=24`, while the add-on image currently ships Node 22.

Fixes #163