### PR TITLE
chore(build): bump add-on runtime to Node 24

### DIFF
--- a/openclaw_assistant/Dockerfile
+++ b/openclaw_assistant/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BUILD_FROM}
 # Base image is Debian Bookworm (glibc). This avoids musl-related native module issues
 # that occur on Alpine (e.g. clipboard, node-llama-cpp).
 
-# Install base packages (without nodejs/npm - we'll get Node 22 from NodeSource)
+# Install base packages (without nodejs/npm - we'll get Node 24 from NodeSource)
 # build-essential provides gcc/cc needed by Homebrew for OpenClaw's brew-managed dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
@@ -34,19 +34,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 22 LTS from NodeSource (Debian Bookworm ships Node 18, but OpenClaw requires 20+)
-# Use explicit keyring + apt source instead of setup_22.x pipe script for deterministic builds.
+# Install Node.js 24 LTS from NodeSource.
+# OpenClaw supports Node >=24.15.0, and this keeps the image compatible with the
+# current mcporter releases without relying on an older pinned CLI line.
+# Use explicit keyring + apt source instead of setup_24.x pipe script for deterministic builds.
 RUN mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
     | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && chmod 644 /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends nodejs \
     && NODE_VERSION="$(node -v)" \
     && echo "$NODE_VERSION" \
-    && echo "$NODE_VERSION" | grep -E '^v22\.' \
+    && echo "$NODE_VERSION" | grep -E '^v24\.' \
     && rm -f /etc/apt/sources.list.d/nodesource.list /etc/apt/keyrings/nodesource.gpg \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- bump the add-on image from NodeSource Node 22 to Node 24 LTS
- keep the change isolated to the Dockerfile so it can be reviewed independently from the MCP packaging PR
- unblock follow-up adoption of the current `mcporter` releases, which require Node `>=24`

## Compatibility audit
Checked package support and smoke-installed the risky packages on **Node v24.15.0** on **Thursday, July 16, 2026**.

Packages explicitly checked:
- `openclaw@2026.7.1`
- `mcporter@0.12.3`
- `node-llama-cpp@3.18.1`
- `@lydell/node-pty@1.2.0-beta.12`
- `@silvia-odwyer/photon-node@0.3.4`
- `playwright-core@1.61.1`

Result:
- no package-level blocker found
- all of the above installed successfully under Node `24.15.0`

## Verification
- `git diff --check`
- downloaded and ran `node-v24.15.0` locally
- install smoke tests under Node `24.15.0` for the packages listed above

## Notes
- OpenClaw currently declares Node support as `>=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0`, so this PR stays within the published support matrix.
- I did **not** find a concrete blocker that should hold this Node bump back.