### PR TITLE
Bump OpenClaw to 2026.7.1-2

### DIFF
--- a/openclaw_assistant/Dockerfile
+++ b/openclaw_assistant/Dockerfile
@@ -121,7 +121,7 @@ USER root
 # Bundle mcporter so Home Assistant MCP auto-configuration works out of the box.
 # The image now ships Node 24, so use the current mcporter line.
 RUN npm config set fund false && npm config set audit false \
-    && npm install -g openclaw@2026.7.1-2 node-llama-cpp@3.18.1 mcporter@0.12.3
+    && npm install -g openclaw@2026.7.1-2-2 node-llama-cpp@3.18.1 mcporter@0.12.3
 
 # Shell aliases and color options for interactive use
 RUN tee -a /etc/bash.bashrc <<'EOF'

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.85"
+version: "0.5.86"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant


### PR DESCRIPTION
Automated update:
- openclaw_assistant/Dockerfile: openclaw@2026.7.1 → openclaw@2026.7.1-2
- openclaw_assistant/config.yaml: add-on version 0.5.85 → 0.5.86

By OpenClaw Home Assistant Bot.