### PR TITLE
fix: correct bundled OpenClaw version for 0.5.87

### DIFF
--- a/openclaw_assistant/CHANGELOG.md
+++ b/openclaw_assistant/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the OpenClaw Assistant Home Assistant Add-on will be documented in this file.
 
+## [0.5.87] - 2026-08-10
+
+### Fixed
+- Correct the bundled OpenClaw npm package version in the Docker image build for add-on `0.5.86`, fixing failed installs that requested the nonexistent `openclaw@2026.7.1-2-2`.
+
 ## [0.5.85] - 2026-07-21
 
 ### Changed

--- a/openclaw_assistant/Dockerfile
+++ b/openclaw_assistant/Dockerfile
@@ -121,7 +121,7 @@ USER root
 # Bundle mcporter so Home Assistant MCP auto-configuration works out of the box.
 # The image now ships Node 24, so use the current mcporter line.
 RUN npm config set fund false && npm config set audit false \
-    && npm install -g openclaw@2026.7.1-2-2 node-llama-cpp@3.18.1 mcporter@0.12.3
+    && npm install -g openclaw@2026.7.1-2 node-llama-cpp@3.18.1 mcporter@0.12.3
 
 # Shell aliases and color options for interactive use
 RUN tee -a /etc/bash.bashrc <<'EOF'

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.86"
+version: "0.5.87"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant


### PR DESCRIPTION
Fixes #168.

## Summary
- correct the bundled npm package version from `openclaw@2026.7.1-2-2` to `openclaw@2026.7.1-2`
- bump the add-on version to `0.5.87`
- add a changelog entry for the hotfix release

## Verification
- confirmed `origin/main` currently contains the broken `openclaw@2026.7.1-2-2` install line
- verified the patched branch now references the valid `openclaw@2026.7.1-2` package version