### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This repository contains a Home Assistant add-on that runs **OpenClaw** inside *
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=techartdev/OpenClawHomeAssistant&type=date&legend=top-left)](https://www.star-history.com/#techartdev/OpenClawHomeAssistant&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=techartdev/OpenClawHomeAssistant&type=date&legend=top-left)](https://star-history.dera.page/#techartdev/OpenClawHomeAssistant&type=date&legend=top-left)
 
 ## Support / Donations
 


### PR DESCRIPTION
The star history chart in the README is currently broken, so the project no longer displays its growth properly. This change points the chart to a working endpoint so it renders again.

No configuration or behavior changes are required; this is purely a documentation fix.