### PR TITLE
fix: preserve explicit false boolean options

### DIFF
--- a/openclaw_assistant/CHANGELOG.md
+++ b/openclaw_assistant/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the OpenClaw Assistant Home Assistant Add-on will be documented in this file.
 
+## [0.5.88] - 2026-08-22
+
+### Fixed
+- Preserve explicit `false` values for boolean add-on options instead of replacing them with `true` defaults during startup. This restores settings such as strict Control UI device authentication, disabled terminal access, and IPv6-capable DNS behavior after an add-on restart or rebuild.
+
 ## [0.5.87] - 2026-08-10
 
 ### Fixed

--- a/openclaw_assistant/config.yaml
+++ b/openclaw_assistant/config.yaml
@@ -1,5 +1,5 @@
 name: OpenClaw Assistant
-version: "0.5.87"
+version: "0.5.88"
 slug: openclaw_assistant
 description: Run OpenClaw Assistant (OpenClaw-compatible) as a Home Assistant add-on.
 url: https://github.com/techartdev/OpenClawHomeAssistant

--- a/openclaw_assistant/run.sh
+++ b/openclaw_assistant/run.sh
@@ -13,6 +13,14 @@ if [ ! -f "$OPTIONS_FILE" ]; then
   exit 1
 fi
 
+read_json_bool() {
+  local key="$1"
+  local default_bool="$2"
+  jq -r --arg key "$key" --argjson default_bool "$default_bool" '
+    if .[$key] == null then $default_bool else .[$key] end
+  ' "$OPTIONS_FILE"
+}
+
 # ------------------------------------------------------------------------------
 # Read add-on options (only add-on-specific knobs; OpenClaw is configured via onboarding)
 # ------------------------------------------------------------------------------
@@ -21,7 +29,7 @@ TZNAME=$(jq -r '.timezone // "Europe/Sofia"' "$OPTIONS_FILE")
 GW_PUBLIC_URL=$(jq -r '.gateway_public_url // empty' "$OPTIONS_FILE")
 HA_TOKEN=$(jq -r '.homeassistant_token // empty' "$OPTIONS_FILE")
 ADDON_HTTP_PROXY=$(jq -r '.http_proxy // empty' "$OPTIONS_FILE")
-ENABLE_TERMINAL=$(jq -r '.enable_terminal // true' "$OPTIONS_FILE")
+ENABLE_TERMINAL=$(read_json_bool enable_terminal true)
 TERMINAL_PORT_RAW=$(jq -r '.terminal_port // 7681' "$OPTIONS_FILE")
 
 # SECURITY: Validate TERMINAL_PORT to prevent nginx config injection
@@ -42,25 +50,25 @@ ROUTER_USER=$(jq -r '.router_ssh_user // empty' "$OPTIONS_FILE")
 ROUTER_KEY=$(jq -r '.router_ssh_key_path // "/data/keys/router_ssh"' "$OPTIONS_FILE")
 
 # Optional: allow disabling lock cleanup if you ever need to debug
-CLEAN_LOCKS_ON_START=$(jq -r '.clean_session_locks_on_start // true' "$OPTIONS_FILE")
-CLEAN_LOCKS_ON_EXIT=$(jq -r '.clean_session_locks_on_exit // true' "$OPTIONS_FILE")
-PERSIST_NODE_GLOBAL=$(jq -r '.persist_node_global // false' "$OPTIONS_FILE")
-PERSIST_BREW_TOOLS=$(jq -r '.persist_brew_tools // false' "$OPTIONS_FILE")
+CLEAN_LOCKS_ON_START=$(read_json_bool clean_session_locks_on_start true)
+CLEAN_LOCKS_ON_EXIT=$(read_json_bool clean_session_locks_on_exit true)
+PERSIST_NODE_GLOBAL=$(read_json_bool persist_node_global false)
+PERSIST_BREW_TOOLS=$(read_json_bool persist_brew_tools false)
 
 # Gateway configuration
 GATEWAY_MODE=$(jq -r '.gateway_mode // "local"' "$OPTIONS_FILE")
 GATEWAY_REMOTE_URL=$(jq -r '.gateway_remote_url // empty' "$OPTIONS_FILE")
 GATEWAY_BIND_MODE=$(jq -r '.gateway_bind_mode // "loopback"' "$OPTIONS_FILE")
 GATEWAY_PORT=$(jq -r '.gateway_port // 18789' "$OPTIONS_FILE")
-ENABLE_OPENAI_API=$(jq -r '.enable_openai_api // false' "$OPTIONS_FILE")
+ENABLE_OPENAI_API=$(read_json_bool enable_openai_api false)
 GATEWAY_AUTH_MODE=$(jq -r '.gateway_auth_mode // "token"' "$OPTIONS_FILE")
 GATEWAY_TRUSTED_PROXIES=$(jq -r '.gateway_trusted_proxies // empty' "$OPTIONS_FILE")
 GATEWAY_ADDITIONAL_ALLOWED_ORIGINS=$(jq -r '.gateway_additional_allowed_origins // empty' "$OPTIONS_FILE")
-CONTROLUI_DISABLE_DEVICE_AUTH=$(jq -r '.controlui_disable_device_auth // true' "$OPTIONS_FILE")
-FORCE_IPV4_DNS=$(jq -r '.force_ipv4_dns // true' "$OPTIONS_FILE")
+CONTROLUI_DISABLE_DEVICE_AUTH=$(read_json_bool controlui_disable_device_auth true)
+FORCE_IPV4_DNS=$(read_json_bool force_ipv4_dns true)
 ACCESS_MODE=$(jq -r '.access_mode // "custom"' "$OPTIONS_FILE")
 NGINX_LOG_LEVEL=$(jq -r '.nginx_log_level // "minimal"' "$OPTIONS_FILE")
-AUTO_CONFIGURE_MCP=$(jq -r '.auto_configure_mcp // false' "$OPTIONS_FILE")
+AUTO_CONFIGURE_MCP=$(read_json_bool auto_configure_mcp false)
 GW_ENV_VARS_TYPE=$(jq -r 'if .gateway_env_vars == null then "null" else (.gateway_env_vars | type) end' "$OPTIONS_FILE")
 GW_ENV_VARS_RAW=$(jq -r '.gateway_env_vars // empty' "$OPTIONS_FILE")
 GW_ENV_VARS_JSON=$(jq -c '.gateway_env_vars // []' "$OPTIONS_FILE")


### PR DESCRIPTION
## Summary

- preserve explicit `false` values from `/data/options.json`
- use one `read_json_bool` helper for the existing boolean add-on options
- bump the add-on to `0.5.88` and document the fix

## Problem

`jq`'s alternative operator treats both `false` and `null` as absent values:

```console
$ jq -n 'false // true'
true
```

As a result, boolean options with a `true` default could not be disabled. For example, `controlui_disable_device_auth: false` was read as `true` during startup, re-enabling `gateway.controlUi.dangerouslyDisableDeviceAuth` after a restart or rebuild.

This is a follow-up to #87 / #88: the option and documentation are correct, but the shell-side read did not preserve the explicit `false` value.

## Scope

The helper is applied only to the boolean options already read by `run.sh`:

- `enable_terminal`
- `clean_session_locks_on_start`
- `clean_session_locks_on_exit`
- `persist_node_global`
- `persist_brew_tools`
- `enable_openai_api`
- `controlui_disable_device_auth`
- `force_ipv4_dns`
- `auto_configure_mcp`

Defaults and schemas are unchanged.

## Validation

- `bash -n openclaw_assistant/run.sh`
- `python3 -m py_compile openclaw_assistant/oc_config_helper.py`
- `python3 -m py_compile openclaw_assistant/render_nginx.py`
- direct helper checks for explicit `false`, explicit `true`, missing-with-`true`-default, and missing-with-`false`-default
- `git diff --check`

— OpenClaw 🦞